### PR TITLE
Fixed incorrect signature

### DIFF
--- a/src/mlpack/methods/sparse_svm/sparse_svm_function.hpp
+++ b/src/mlpack/methods/sparse_svm/sparse_svm_function.hpp
@@ -49,9 +49,13 @@ class SparseSVMFunction
    * @param parameters The parameters of the SVM.
    * @param id Index of the datapoint to use for the gradient evaluation.
    * @param gradient Sparse matrix to output the gradient into.
+   * @param batchSize Size of batch to process
    */
   template <typename GradType>
-  void Gradient(const arma::mat& parameters, size_t id, GradType& gradient);
+  void Gradient(const arma::mat& parameters,
+                const size_t firstId,
+                GradType& gradient,
+                const size_t batchSize = 1);
 
   //! Return the initial point for the optimization.
   const arma::mat& InitialPoint() const { return initialPoint; }

--- a/src/mlpack/methods/sparse_svm/sparse_svm_function_impl.hpp
+++ b/src/mlpack/methods/sparse_svm/sparse_svm_function_impl.hpp
@@ -48,11 +48,10 @@ double SparseSVMFunction::Evaluate(const arma::mat& parameters,
 }
 
 template <typename GradType>
-void SparseSVMFunction::Gradient(
-    const arma::mat& parameters,
-    const size_t firstId,
-    GradType& gradient,
-    const size_t batchSize)
+void SparseSVMFunction::Gradient(const arma::mat& parameters,
+                                 const size_t firstId,
+                                 GradType& gradient,
+                                 const size_t batchSize)
 {
   // Evaluate the gradient of the hinge loss function.
   const size_t lastId = firstId + batchSize - 1;


### PR DESCRIPTION
Signature for SparseSVMFunction::Gradient() inside "src/mlpack/methods/sparse_svm/sparse_svm_function.hpp" was incorrect