### PR TITLE
fixed SparseSVMFunction::Evaluate() and  fixed an issue in SparseSVM::Classify()

### DIFF
--- a/src/mlpack/methods/sparse_svm/sparse_svm.cpp
+++ b/src/mlpack/methods/sparse_svm/sparse_svm.cpp
@@ -31,8 +31,12 @@ void SparseSVM::Classify(const arma::mat& dataset,
                          arma::Row<size_t>& labels)
     const
 {
-  labels = arma::sign(parameters.cols(dataset.n_elem) * dataset +
-                      parameters.tail_cols(dataset.n_elem));
+  arma::mat predictions = parameters.head_cols(dataset.n_elem) * dataset +
+      parameters.tail_cols(dataset.n_elem);
+
+  // Classify each point of dataset into {-1, 1} depending whether
+  // predictions is positive or negative.
+  labels = arma::sign(arma::conv_to<arma::Row<size_t>>::from(predictions));
 }
 
 double SparseSVM::ComputeAccuracy(const arma::mat& testData,

--- a/src/mlpack/methods/sparse_svm/sparse_svm_function_impl.hpp
+++ b/src/mlpack/methods/sparse_svm/sparse_svm_function_impl.hpp
@@ -48,9 +48,10 @@ double SparseSVMFunction::Evaluate(const arma::mat& parameters,
 {
   // The hinge loss function.
   const size_t lastId = firstId + batchSize - 1;
-  return arma::accu(arma::max(0.0, 1 - labels.subvec(firstId, lastId) %
-      dataset.cols(firstId, lastId) *
-      arma::repmat(parameters, 1, batchSize).t()));
+  arma::vec dots = 1 - labels.subvec(firstId, lastId) %
+       dataset.cols(firstId, lastId) *
+       arma::repmat(parameters, 1, batchSize).t();
+  return arma::accu(arma::clamp(dots, 0.0, dots.max()));
 }
 
 template <typename GradType>
@@ -97,9 +98,7 @@ double SparseSVMFunction::EvaluateWithGradient(const arma::mat& parameters,
   }
 
   // The hinge loss function.
-  return arma::accu(arma::max(0.0, 1 - labels.subvec(firstId, lastId) %
-                                       dataset.cols(firstId, lastId) *
-                                       arma::repmat(parameters, 1, batchSize).t()));
+  return arma::accu(arma::clamp(dots, 0.0, dots.max()));
 }
 
 size_t SparseSVMFunction::NumFunctions()


### PR DESCRIPTION
Fixes: 

- Updated the function definition for `SparseSVMFunction::Evaluate()` and `SparseSVMFunction::EvaluateWithGradient()` and used `arma::clamp()`.

- The issue was related to typecasting. The parameter inside `arma::size()` should have the same type as that of `labels`.